### PR TITLE
Add mirage as dependency and add YYYY-mm-dd'T'HH:MM:SS.sss'Z' support to datetime formatting #1 

### DIFF
--- a/misc_jwst/engdb.py
+++ b/misc_jwst/engdb.py
@@ -36,11 +36,17 @@ def get_ictm_event_log(startdate='2022-02-01', enddate=None, mast_api_token=None
     session.headers.update({'Authorization': f'token {mast_api_token}'})
 
     # fetch event messages from MAST engineering database (lags FOS EDB)
-    start = datetime.fromisoformat(f'{startdate}+00:00')
+    try :
+        start = datetime.strptime(startdate, "%Y-%m-%dT%H:%M:%S.%f%z")
+    except Exception as e:
+        start = datetime.fromisoformat(f'{startdate}+00:00')
     if enddate is None:
         end = datetime.now(tz=tz_utc)
     else:
-        end = datetime.fromisoformat(f'{enddate}+23:59:59')
+        try :
+            end = datetime.strptime(enddate, "%Y-%m-%dT%H:%M:%S.%f%z")
+        except Exception as e:
+            end = datetime.fromisoformat(f'{enddate}+23:59:59')
 
     startstr = start.strftime(mastfmt)
     endstr = end.strftime(mastfmt)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ setup_requires =
 install_requires =
     numpy>=1.17
     astropy>=4
+    mirage
 python_requires = >=3.7
 
 [options.extras_require]


### PR DESCRIPTION
 Fix Usability issues: add mirage as dependency and robustness to datetime formatting #1 